### PR TITLE
Update to work with recent PDF.js lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ Now visit `index.html` in your browser, you should see the demo page with thumbn
 You just need to keep the `pdfThumbnails.js` file from this project, and the `pdf.js` and `pdf.worker.js` files from pdf.js
 (let them both in the same directory as pdf.js will try to load the worker). In your html file, include the javascripts:
 ```html
-<script src="/path/to/pdf.js"></script>
-<script src="/path/to/pdfThumbnails.js"></script>
+<script src="/path/to/pdfThumbnails.js" data-pdfjs-src="/path/to/pdf.js/build/pdf.js"></script>
 ```
+
+The `data-pdfjs-src` attribute specifies the path of the library, which will only be loaded if there's any PDF thumbnail to display in the page.
+
 To show a thumbnail, write an `img` element with a `data-pdf-thumbnail-file` attribute:
 ```html
 <img data-pdf-thumbnail-file="/my/file.pdf">

--- a/index.html
+++ b/index.html
@@ -15,8 +15,7 @@
     <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
     <!-- PDF.js and Simple PDF Thumbnail scripts -->
-    <script src="pdfjs/build/pdf.js"></script>
-    <script src="pdfThumbnails.js"></script>
+    <script src="pdfThumbnails.js" data-pdfjs-src="pdf.js/build/pdf.js"></script>
     <style>
 
     </style>

--- a/pdfThumbnails.js
+++ b/pdfThumbnails.js
@@ -7,47 +7,77 @@
  */
 var createPDFThumbnails = function(){
 
-    if (typeof pdfjsLib === 'undefined') {
-        throw Error("pdf.js is not loaded. Please include it before pdfThumbnails.js.");
-    }
-    pdfjsLib.disableWorker = true;
+    var worker = null;
+    var loaded = false;
+    var renderQueue = [];
 
     // select all img elements with data-pdf-thumbnail-file attribute
     var nodesArray = Array.prototype.slice.call(document.querySelectorAll('img[data-pdf-thumbnail-file]'));
 
-    nodesArray.forEach(function(element) {
-        var filePath = element.getAttribute('data-pdf-thumbnail-file');
-        var imgWidth = element.getAttribute('data-pdf-thumbnail-width');
-        var imgHeight = element.getAttribute('data-pdf-thumbnail-height');
+    if (!nodesArray.length) {
+        // No PDF found, don't load PDF.js
+        return;
+    }
 
-        pdfjsLib.getDocument(filePath).then(function (pdf) {
-            pdf.getPage(1).then(function (page) {
-                var canvas = document.createElement("canvas");
-                var viewport = page.getViewport(1.0);
-                var context = canvas.getContext('2d');
+    if (!loaded && typeof(pdfjsLib) === 'undefined') {
+        var src = document.querySelector('script[data-pdfjs-src]').getAttribute('data-pdfjs-src');
 
-                if (imgWidth) {
-                    viewport = page.getViewport(imgWidth / viewport.width);
-                } else if (imgHeight) {
-                    viewport = page.getViewport(imgHeight / viewport.height);
-                }
+        if (!src) {
+            throw Error('PDF.js URL not set in "data-pdfjs-src" attribute: cannot load PDF.js');
+        }
 
-                canvas.height = viewport.height;
-                canvas.width = viewport.width;
+        var script = document.createElement('script');
+        script.src = src;
+        document.head.appendChild(script).onload = renderThumbnails;
+        loaded = true;
+    }
+    else {
+        renderThumbnails();
+    }
 
-                page.render({
-                    canvasContext: context,
-                    viewport: viewport
-                }).then(function () {
-                    element.src = canvas.toDataURL();
+    function renderThumbnails() {
+        if (!pdfjsLib) {
+            throw Error("pdf.js failed to load. Check data-pdfjs-src attribute.");
+        }
+
+        nodesArray.forEach(function(element) {
+            if (null === worker) {
+                worker = new pdfjsLib.PDFWorker();
+            }
+
+            var filePath = element.getAttribute('data-pdf-thumbnail-file');
+            var imgWidth = element.getAttribute('data-pdf-thumbnail-width');
+            var imgHeight = element.getAttribute('data-pdf-thumbnail-height');
+
+            pdfjsLib.getDocument({url: filePath, worker: worker}).promise.then(function (pdf) {
+                pdf.getPage(1).then(function (page) {
+                    var canvas = document.createElement("canvas");
+                    var viewport = page.getViewport({scale: 1.0});
+                    var context = canvas.getContext('2d');
+
+                    if (imgWidth) {
+                        viewport = page.getViewport({scale: imgWidth / viewport.width});
+                    } else if (imgHeight) {
+                        viewport = page.getViewport({scale: imgHeight / viewport.height});
+                    }
+
+                    canvas.height = viewport.height;
+                    canvas.width = viewport.width;
+
+                    page.render({
+                        canvasContext: context,
+                        viewport: viewport
+                    }).promise.then(function () {
+                        element.src = canvas.toDataURL();
+                    });
+                }).catch(function() {
+                    console.log("pdfThumbnails error: could not open page 1 of document " + filePath + ". Not a pdf ?");
                 });
             }).catch(function() {
-                console.log("pdfThumbnails error: could not open page 1 of document " + filePath + ". Not a pdf ?");
+                console.log("pdfThumbnails error: could not find or open document " + filePath + ". Not a pdf ?");
             });
-        }).catch(function() {
-            console.log("pdfThumbnails error: could not find or open document " + filePath + ". Not a pdf ?");
         });
-    });
+    }
 };
 
 if (


### PR DESCRIPTION
I updated the script to work with the more recent releases of PDF.js:

* Update deprecated API calls
* Make sure the worker is re-used between documents, and not loaded multiple times

I also added a dynamic loading of the PDF.js library, so that it doesn't get loaded every time even when there is no PDF thumbnail to generate in the page.